### PR TITLE
Move scripts and styles to item template

### DIFF
--- a/item.php
+++ b/item.php
@@ -43,14 +43,13 @@ if (!$itemObj) {
 $GLOBALS['xoopsOption']['template_main'] = 'publisher_item.tpl';
 include_once $GLOBALS['xoops']->path('header.php');
 
-$xoTheme->addScript(XOOPS_URL . '/browse.php?Frameworks/jquery/jquery.js');
-$xoTheme->addScript(PUBLISHER_URL . '/assets/js/jquery.popeye-2.1.js');
-//$xoTheme->addScript(PUBLISHER_URL . '/assets/js/jquery.popeye-2.0.4.js');
-$xoTheme->addScript(PUBLISHER_URL . '/assets/js/publisher.js');
+//$xoTheme->addScript(XOOPS_URL . '/browse.php?Frameworks/jquery/jquery.js');
+//$xoTheme->addScript(PUBLISHER_URL . '/assets/js/jquery.popeye-2.1.js');
+//$xoTheme->addScript(PUBLISHER_URL . '/assets/js/publisher.js');
 
-$xoTheme->addStylesheet(PUBLISHER_URL . '/assets/css/jquery.popeye.css');
-$xoTheme->addStylesheet(PUBLISHER_URL . '/assets/css/jquery.popeye.style.css');
-$xoTheme->addStylesheet(PUBLISHER_URL . '/assets/css/publisher.css');
+//$xoTheme->addStylesheet(PUBLISHER_URL . '/assets/css/jquery.popeye.css');
+//$xoTheme->addStylesheet(PUBLISHER_URL . '/assets/css/jquery.popeye.style.css');
+//$xoTheme->addStylesheet(PUBLISHER_URL . '/assets/css/publisher.css');
 
 include_once PUBLISHER_ROOT_PATH . '/footer.php';
 

--- a/templates/publisher_item.tpl
+++ b/templates/publisher_item.tpl
@@ -1,5 +1,13 @@
 <{include file='db:publisher_header.tpl'}>
 
+<script src="<{xoAppUrl browse.php?Frameworks/jquery/jquery.js}>"></script>
+<script src="<{$publisher_url}>/assets/js/jquery.popeye-2.1.js"></script>
+<script src="<{$publisher_url}>/assets/js/publisher.js"></script>
+
+<link rel="stylesheet" type="text/css" href="<{$publisher_url}>/assets/css/jquery.popeye.css">
+<link rel="stylesheet" type="text/css" href="<{$publisher_url}>/assets/css/jquery.popeye.style.css">
+<link rel="stylesheet" type="text/css" href="<{$publisher_url}>/assets/css/publisher.css">
+
 <div class="item">
     <h2><{$item.title}></h2>
     <{if $show_subtitle && $item.subtitle}>
@@ -18,7 +26,7 @@
         <{/if}>
         <div class="itemText">
             <{if $item.image_path || $item.images}>
-                <div class="ppy" id="ppy1">
+                <div class="ppy" id="ppy3">
                     <ul class="ppy-imglist">
                         <{if $item.image_path}>
                             <li>
@@ -191,7 +199,7 @@
             caption: 'permanent'
         };
 
-        $publisher('#ppy1').popeye(options);
+        $publisher('#ppy3').popeye(options);
     });
     //]]>-->
 </script>


### PR DESCRIPTION
- jquery and popeye asset loads to template due to conflicts when overriding in theme
- switch to a color neutral skin for popeye