### PR TITLE
 Notification Title tag inadvertently overloaded

### DIFF
--- a/class/Item.php
+++ b/class/Item.php
@@ -525,7 +525,7 @@ class Item extends \XoopsObject
 
         $tags['MODULE_NAME']   = $this->helper->getModule()->getVar('name');
         $tags['ITEM_NAME']     = $this->getTitle();
-        $tags['ITEM_NAME']     = $this->subtitle();
+        $tags['ITEM_SUBNAME']  = $this->getSubtitle();
         $tags['CATEGORY_NAME'] = $this->getCategoryName();
         $tags['CATEGORY_URL']  = PUBLISHER_URL . '/category.php?categoryid=' . $this->categoryid();
         $tags['ITEM_BODY']     = $this->body();


### PR DESCRIPTION
Change to allow both Title and SubTitle tags in notification templates